### PR TITLE
Meilleure gestion des fuseaux horaires

### DIFF
--- a/admin_bans.php
+++ b/admin_bans.php
@@ -92,7 +92,7 @@ if (isset($_REQUEST['add_ban']) || isset($_GET['edit_ban']))
 		else
 			message($lang_common['Bad request'], false, '404 Not Found');
 
-		$diff = ($pun_user['timezone'] + $pun_user['dst']) * 3600;
+		$diff = timezone_get_offset($pun_user['timezone']);
 		$ban_expire = ($ban_expire != '') ? gmdate('Y-m-d', $ban_expire + $diff) : '';
 
 		$mode = 'edit';
@@ -303,7 +303,7 @@ else if (isset($_POST['add_edit_ban']))
 		if ($ban_expire == -1 || !$ban_expire)
 			message($lang_admin_bans['Invalid date message'].' '.$lang_admin_bans['Invalid date reasons']);
 
-		$diff = ($pun_user['timezone'] + $pun_user['dst']) * 3600;
+		$diff = timezone_get_offset($pun_user['timezone']);
 		$ban_expire -= $diff;
 
 		if ($ban_expire <= time())

--- a/admin_bans.php
+++ b/admin_bans.php
@@ -92,7 +92,10 @@ if (isset($_REQUEST['add_ban']) || isset($_GET['edit_ban']))
 		else
 			message($lang_common['Bad request'], false, '404 Not Found');
 
+		// MODIF RL Bohwaz amélioration des Timezone.
 		$diff = timezone_get_offset($pun_user['timezone']);
+		// FIN MODIF Bohwaz
+
 		$ban_expire = ($ban_expire != '') ? gmdate('Y-m-d', $ban_expire + $diff) : '';
 
 		$mode = 'edit';

--- a/admin_options.php
+++ b/admin_options.php
@@ -28,8 +28,7 @@ if (isset($_POST['form_sent']))
 		'board_title'			=> pun_trim($_POST['form']['board_title']),
 		'board_desc'			=> pun_trim($_POST['form']['board_desc']),
 		'base_url'				=> pun_trim($_POST['form']['base_url']),
-		'default_timezone'		=> floatval($_POST['form']['default_timezone']),
-		'default_dst'			=> $_POST['form']['default_dst'] != '1' ? '0' : '1',
+		'default_timezone'		=> trim($_POST['form']['default_timezone']),
 		'default_lang'			=> pun_trim($_POST['form']['default_lang']),
 		'default_style'			=> pun_trim($_POST['form']['default_style']),
 		'time_format'			=> pun_trim($_POST['form']['time_format']),
@@ -263,57 +262,9 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Timezone label'] ?></th>
 									<td>
-										<select name="form[default_timezone]">
-											<option value="-12"<?php if ($pun_config['o_default_timezone'] == -12) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-12:00'] ?></option>
-											<option value="-11"<?php if ($pun_config['o_default_timezone'] == -11) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-11:00'] ?></option>
-											<option value="-10"<?php if ($pun_config['o_default_timezone'] == -10) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-10:00'] ?></option>
-											<option value="-9.5"<?php if ($pun_config['o_default_timezone'] == -9.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-09:30'] ?></option>
-											<option value="-9"<?php if ($pun_config['o_default_timezone'] == -9) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-09:00'] ?></option>
-											<option value="-8.5"<?php if ($pun_config['o_default_timezone'] == -8.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-08:30'] ?></option>
-											<option value="-8"<?php if ($pun_config['o_default_timezone'] == -8) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-08:00'] ?></option>
-											<option value="-7"<?php if ($pun_config['o_default_timezone'] == -7) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-07:00'] ?></option>
-											<option value="-6"<?php if ($pun_config['o_default_timezone'] == -6) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-06:00'] ?></option>
-											<option value="-5"<?php if ($pun_config['o_default_timezone'] == -5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-05:00'] ?></option>
-											<option value="-4"<?php if ($pun_config['o_default_timezone'] == -4) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-04:00'] ?></option>
-											<option value="-3.5"<?php if ($pun_config['o_default_timezone'] == -3.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-03:30'] ?></option>
-											<option value="-3"<?php if ($pun_config['o_default_timezone'] == -3) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-03:00'] ?></option>
-											<option value="-2"<?php if ($pun_config['o_default_timezone'] == -2) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-02:00'] ?></option>
-											<option value="-1"<?php if ($pun_config['o_default_timezone'] == -1) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC-01:00'] ?></option>
-											<option value="0"<?php if ($pun_config['o_default_timezone'] == 0) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC'] ?></option>
-											<option value="1"<?php if ($pun_config['o_default_timezone'] == 1) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+01:00'] ?></option>
-											<option value="2"<?php if ($pun_config['o_default_timezone'] == 2) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+02:00'] ?></option>
-											<option value="3"<?php if ($pun_config['o_default_timezone'] == 3) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+03:00'] ?></option>
-											<option value="3.5"<?php if ($pun_config['o_default_timezone'] == 3.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+03:30'] ?></option>
-											<option value="4"<?php if ($pun_config['o_default_timezone'] == 4) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+04:00'] ?></option>
-											<option value="4.5"<?php if ($pun_config['o_default_timezone'] == 4.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+04:30'] ?></option>
-											<option value="5"<?php if ($pun_config['o_default_timezone'] == 5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+05:00'] ?></option>
-											<option value="5.5"<?php if ($pun_config['o_default_timezone'] == 5.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+05:30'] ?></option>
-											<option value="5.75"<?php if ($pun_config['o_default_timezone'] == 5.75) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+05:45'] ?></option>
-											<option value="6"<?php if ($pun_config['o_default_timezone'] == 6) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+06:00'] ?></option>
-											<option value="6.5"<?php if ($pun_config['o_default_timezone'] == 6.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+06:30'] ?></option>
-											<option value="7"<?php if ($pun_config['o_default_timezone'] == 7) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+07:00'] ?></option>
-											<option value="8"<?php if ($pun_config['o_default_timezone'] == 8) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+08:00'] ?></option>
-											<option value="8.75"<?php if ($pun_config['o_default_timezone'] == 8.75) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+08:45'] ?></option>
-											<option value="9"<?php if ($pun_config['o_default_timezone'] == 9) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+09:00'] ?></option>
-											<option value="9.5"<?php if ($pun_config['o_default_timezone'] == 9.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+09:30'] ?></option>
-											<option value="10"<?php if ($pun_config['o_default_timezone'] == 10) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+10:00'] ?></option>
-											<option value="10.5"<?php if ($pun_config['o_default_timezone'] == 10.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+10:30'] ?></option>
-											<option value="11"<?php if ($pun_config['o_default_timezone'] == 11) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+11:00'] ?></option>
-											<option value="11.5"<?php if ($pun_config['o_default_timezone'] == 11.5) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+11:30'] ?></option>
-											<option value="12"<?php if ($pun_config['o_default_timezone'] == 12) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+12:00'] ?></option>
-											<option value="12.75"<?php if ($pun_config['o_default_timezone'] == 12.75) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+12:45'] ?></option>
-											<option value="13"<?php if ($pun_config['o_default_timezone'] == 13) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+13:00'] ?></option>
-											<option value="14"<?php if ($pun_config['o_default_timezone'] == 14) echo ' selected="selected"' ?>><?php echo $lang_admin_options['UTC+14:00'] ?></option>
-										</select>
+										<?=html_timezone_select('form[default_timezone]', $pun_config['o_default_timezone'])?>
+
 										<span><?php echo $lang_admin_options['Timezone help'] ?></span>
-									</td>
-								</tr>
-								<tr>
-									<th scope="row"><?php echo $lang_admin_options['DST label'] ?></th>
-									<td>
-										<label class="conl"><input type="radio" name="form[default_dst]" value="1"<?php if ($pun_config['o_default_dst'] == '1') echo ' checked="checked"' ?> />&#160;<strong><?php echo $lang_admin_common['Yes'] ?></strong></label>
-										<label class="conl"><input type="radio" name="form[default_dst]" value="0"<?php if ($pun_config['o_default_dst'] == '0') echo ' checked="checked"' ?> />&#160;<strong><?php echo $lang_admin_common['No'] ?></strong></label>
-										<span class="clearb"><?php echo $lang_admin_options['DST help'] ?></span>
 									</td>
 								</tr>
 								<tr>
@@ -364,8 +315,7 @@ generate_admin_menu('options');
 				</div>
 <?php
 
-	$diff = ($pun_user['timezone'] + $pun_user['dst']) * 3600;
-	$timestamp = time() + $diff;
+	$timestamp = time() + timezone_get_offset($pun_user['timezone']);
 
 ?>
 				<div class="inform">

--- a/admin_options.php
+++ b/admin_options.php
@@ -28,7 +28,9 @@ if (isset($_POST['form_sent']))
 		'board_title'			=> pun_trim($_POST['form']['board_title']),
 		'board_desc'			=> pun_trim($_POST['form']['board_desc']),
 		'base_url'				=> pun_trim($_POST['form']['base_url']),
+		// MODIF RL Bohwaz amélioration des Timezone.
 		'default_timezone'		=> trim($_POST['form']['default_timezone']),
+		// FIN MODIF Bohwaz
 		'default_lang'			=> pun_trim($_POST['form']['default_lang']),
 		'default_style'			=> pun_trim($_POST['form']['default_style']),
 		'time_format'			=> pun_trim($_POST['form']['time_format']),
@@ -262,11 +264,16 @@ generate_admin_menu('options');
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Timezone label'] ?></th>
 									<td>
+										<?php // MODIF RL Bohwaz amélioration des Timezone. ?>
 										<?=html_timezone_select('form[default_timezone]', $pun_config['o_default_timezone'])?>
+										<?php // FIN MODIF Bohwaz ?>
 
 										<span><?php echo $lang_admin_options['Timezone help'] ?></span>
 									</td>
 								</tr>
+								// MODIF RL Bohwaz amélioration des Timezone.
+								// Suppression bouton heure d'été
+								// FIN MODIF Bohwaz
 								<tr>
 									<th scope="row"><?php echo $lang_admin_options['Language label'] ?></th>
 									<td>
@@ -315,7 +322,9 @@ generate_admin_menu('options');
 				</div>
 <?php
 
+	// MODIF RL Bohw// MODIF RL Bohwaz amélioration des Timezone.az amélioration des Timezone.
 	$timestamp = time() + timezone_get_offset($pun_user['timezone']);
+	// FIN MODIF Bohwaz
 
 ?>
 				<div class="inform">

--- a/admin_users.php
+++ b/admin_users.php
@@ -582,7 +582,9 @@ else if (isset($_POST['ban_users']) || isset($_POST['ban_users_comply']))
 			if ($ban_expire == -1 || !$ban_expire)
 				message($lang_admin_users['Invalid date message'].' '.$lang_admin_users['Invalid date reasons']);
 
+			// MODIF RL Bohwaz amélioration des Timezone.
 			$diff = timezone_get_offset($pun_user['timezone']);
+			// FIN MODIF Bohwaz
 			$ban_expire -= $diff;
 
 			if ($ban_expire <= time())

--- a/admin_users.php
+++ b/admin_users.php
@@ -582,7 +582,7 @@ else if (isset($_POST['ban_users']) || isset($_POST['ban_users_comply']))
 			if ($ban_expire == -1 || !$ban_expire)
 				message($lang_admin_users['Invalid date message'].' '.$lang_admin_users['Invalid date reasons']);
 
-			$diff = ($pun_user['timezone'] + $pun_user['dst']) * 3600;
+			$diff = timezone_get_offset($pun_user['timezone']);
 			$ban_expire -= $diff;
 
 			if ($ban_expire <= time())

--- a/db_update.php
+++ b/db_update.php
@@ -712,8 +712,69 @@ switch ($stage)
 		// Make the message field MEDIUMTEXT to allow proper conversion of 65535 character posts to UTF-8
 		$db->alter_field('posts', 'message', 'MEDIUMTEXT', true) or error('Unable to alter message field', __FILE__, __LINE__, $db->error());
 
-		// Add the DST option to the users table
-		$db->add_field('users', 'dst', 'TINYINT(1)', false, 0, 'timezone') or error('Unable to add dst field', __FILE__, __LINE__, $db->error());
+		// Remove DST option, migrate timezones
+		if (array_key_exists('o_default_dst', $pun_config)) {
+			$db->drop_field('users', 'dst') or error('Unable to drop dst field', __FILE__, __LINE__, $db->error());
+			$db->alter_field('users', 'timezone', 'VARCHAR(255)', false) or error('Unable to alter timezone field', __FILE__, __LINE__, $db->error());
+			$db->query(sprintf('DELETE FROM %sconfig WHERE conf_name = \'%s\'', $db->prefix, 'o_default_dst'));
+
+
+			// Migrate timezones from offsets to names
+			$tz_table = [
+				-12   => 'Europe/London', // Doesn't exist
+				-11   => 'Pacific/Apia',
+				-10   => 'Pacific/Honolulu',
+				-9.5  => 'Pacific/Marquesas',
+				-9    => 'America/Anchorage',
+				-8.5  => 'America/Vancouver', // Doesn't exist either
+				-8    => 'America/Vancouver',
+				-7    => 'America/Denver',
+				-6    => 'America/Chicago',
+				-5    => 'America/New_York',
+				-4    => 'America/Halifax',
+				-3.5  => 'America/St_Johns',
+				-3    => 'America/Sao_Paulo',
+				-2    => 'America/Noronha',
+				-1    => 'Atlantic/Azores',
+				0     => 'Europe/Londo',
+				1     => 'Europe/Paris',
+				2     => 'Europe/Helsinki',
+				3     => 'Europe/Moscow',
+				3.5   => 'Asia/Tehran',
+				4     => 'Asia/Dubai',
+				4.5   => 'Asia/Kabul',
+				5     => 'Asia/Karachi',
+				5.5   => 'Asia/Kolkata',
+				6     => 'Asia/Urumqi',
+				6.5   => 'Asia/Rangoon',
+				7     => 'Asia/Tomsk',
+				8     => 'Asia/Shanghai',
+				8.75  => 'Australia/Eucla',
+				9     => 'Asia/Tokyo',
+				9.5   => 'Australia/Adelaide',
+				10    => 'Australia/Melbourne',
+				10.5  => 'Australia/Lord_Howe',
+				11    => 'Pacific/Noumea',
+				11.5  => 'Pacific/Norfolk', // Doesn't exist
+				12    => 'Pacific/Auckland',
+				12.75 => 'Pacific/Chatham',
+				13    => 'Pacific/Apia',
+				14    => 'Pacific/Kiritimati',
+			];
+
+			foreach ($tz_table as $offset => &$name) {
+				try {
+					$tz = new \DateTimeZone($name);
+				}
+				catch (\Exception $e) {
+					$name = 'UTC';
+				}
+
+				$db->query(sprintf('UPDATE %susers SET timezone = \'%s\' WHERE timezone = \'%s\';', $db->prefix, $db->escape($name), $db->escape($offset)));
+			}
+
+			$db->query(sprintf('UPDATE %sconfig SET conf_value = \'%s\' WHERE conf_name = \'o_default_timezone\'', $db->prefix, $db->escape($tz_table[$default_offset])));
+		}
 
 		// Add the last_post column to the online table
 		$db->add_field('online', 'last_post', 'INT(10) UNSIGNED', true, null, null) or error('Unable to add last_post field', __FILE__, __LINE__, $db->error());
@@ -764,10 +825,6 @@ switch ($stage)
 		// Insert new config option o_smtp_ssl
 		if (!array_key_exists('o_smtp_ssl', $pun_config))
 			$db->query('INSERT INTO '.$db->prefix.'config (conf_name, conf_value) VALUES (\'o_smtp_ssl\', \'0\')') or error('Unable to insert config value \'o_smtp_ssl\'', __FILE__, __LINE__, $db->error());
-
-		// Insert new config option o_default_dst
-		if (!array_key_exists('o_default_dst', $pun_config))
-			$db->query('INSERT INTO '.$db->prefix.'config (conf_name, conf_value) VALUES (\'o_default_dst\', \'0\')') or error('Unable to insert config value \'o_default_dst\'', __FILE__, __LINE__, $db->error());
 
 		// Insert new config option o_quote_depth
 		if (!array_key_exists('o_quote_depth', $pun_config))
@@ -1018,8 +1075,8 @@ switch ($stage)
 		$db->add_field('bans', 'ban_creator', 'INT(10) UNSIGNED', false, 0) or error('Unable to add ban_creator field', __FILE__, __LINE__, $db->error());
 
 		// Add the time/date format settings to the user table
-		$db->add_field('users', 'time_format', 'TINYINT(1)', false, 0, 'dst') or error('Unable to add time_format field', __FILE__, __LINE__, $db->error());
-		$db->add_field('users', 'date_format', 'TINYINT(1)', false, 0, 'dst') or error('Unable to add date_format field', __FILE__, __LINE__, $db->error());
+		$db->add_field('users', 'time_format', 'TINYINT(1)', false, 0, 'timezone') or error('Unable to add time_format field', __FILE__, __LINE__, $db->error());
+		$db->add_field('users', 'date_format', 'TINYINT(1)', false, 0, 'timezone') or error('Unable to add date_format field', __FILE__, __LINE__, $db->error());
 
 		// Change the search_data column to mediumtext
 		$db->alter_field('search_cache', 'search_data', 'MEDIUMTEXT', true) or error('Unable to alter search_data field', __FILE__, __LINE__, $db->error());

--- a/db_update.php
+++ b/db_update.php
@@ -712,6 +712,7 @@ switch ($stage)
 		// Make the message field MEDIUMTEXT to allow proper conversion of 65535 character posts to UTF-8
 		$db->alter_field('posts', 'message', 'MEDIUMTEXT', true) or error('Unable to alter message field', __FILE__, __LINE__, $db->error());
 
+		// MODIF RL Bohwaz amélioration des Timezone.
 		// Remove DST option, migrate timezones
 		if (array_key_exists('o_default_dst', $pun_config)) {
 			$db->drop_field('users', 'dst') or error('Unable to drop dst field', __FILE__, __LINE__, $db->error());
@@ -775,6 +776,7 @@ switch ($stage)
 
 			$db->query(sprintf('UPDATE %sconfig SET conf_value = \'%s\' WHERE conf_name = \'o_default_timezone\'', $db->prefix, $db->escape($tz_table[$default_offset])));
 		}
+		// FIN MODIF Bohwaz
 
 		// Add the last_post column to the online table
 		$db->add_field('online', 'last_post', 'INT(10) UNSIGNED', true, null, null) or error('Unable to add last_post field', __FILE__, __LINE__, $db->error());
@@ -825,6 +827,10 @@ switch ($stage)
 		// Insert new config option o_smtp_ssl
 		if (!array_key_exists('o_smtp_ssl', $pun_config))
 			$db->query('INSERT INTO '.$db->prefix.'config (conf_name, conf_value) VALUES (\'o_smtp_ssl\', \'0\')') or error('Unable to insert config value \'o_smtp_ssl\'', __FILE__, __LINE__, $db->error());
+
+		// MODIF RL Bohwaz amélioration des Timezone.
+		// Suppression config heure d'été
+		// FIN MODIF Bohwaz
 
 		// Insert new config option o_quote_depth
 		if (!array_key_exists('o_quote_depth', $pun_config))
@@ -1074,9 +1080,11 @@ switch ($stage)
 		// Add the ban_creator column to the bans table
 		$db->add_field('bans', 'ban_creator', 'INT(10) UNSIGNED', false, 0) or error('Unable to add ban_creator field', __FILE__, __LINE__, $db->error());
 
+		// MODIF RL Bohwaz amélioration des Timezone.
 		// Add the time/date format settings to the user table
 		$db->add_field('users', 'time_format', 'TINYINT(1)', false, 0, 'timezone') or error('Unable to add time_format field', __FILE__, __LINE__, $db->error());
 		$db->add_field('users', 'date_format', 'TINYINT(1)', false, 0, 'timezone') or error('Unable to add date_format field', __FILE__, __LINE__, $db->error());
+		// FIN MODIF Bohwaz
 
 		// Change the search_data column to mediumtext
 		$db->alter_field('search_cache', 'search_data', 'MEDIUMTEXT', true) or error('Unable to alter search_data field', __FILE__, __LINE__, $db->error());

--- a/header.php
+++ b/header.php
@@ -102,7 +102,7 @@ if (!defined('PUN_ALLOW_INDEX'))
 
 ?>
 <title><?php echo generate_page_title($page_title, $p) ?></title>
-<?php require PUN_ROOT.'plugins/ezbbc/ezbbc_head.php'; ?>
+<?php require PUN_ROOT.'plugins/ezbbc/ezbbc_head_async.php'; ?>
 <?php
 // MODIF RL
 // OPITUX

--- a/include/functions.php
+++ b/include/functions.php
@@ -305,7 +305,6 @@ function set_default_user()
 	$pun_user['disp_topics'] = $pun_config['o_disp_topics_default'];
 	$pun_user['disp_posts'] = $pun_config['o_disp_posts_default'];
 	$pun_user['timezone'] = $pun_config['o_default_timezone'];
-	$pun_user['dst'] = $pun_config['o_default_dst'];
 	$pun_user['language'] = $pun_config['o_default_lang'];
 	$pun_user['style'] = $pun_config['o_default_style'];
 	$pun_user['is_guest'] = true;
@@ -989,7 +988,7 @@ function format_time($timestamp, $date_only = false, $date_format = null, $time_
 	if (is_null($user))
 		$user = $pun_user;
 
-	$diff = ($user['timezone'] + $user['dst']) * 3600;
+	$diff = timezone_get_offset($user['timezone']);
 	$timestamp += $diff;
 	$now = time();
 
@@ -2243,4 +2242,61 @@ function dump()
 
 	echo '</pre>';
 	exit;
+}
+
+
+function html_timezone_select($name, $selected = null) {
+	$out = sprintf('<select name="%s">', $name);
+
+	$tz_list = \DateTimeZone::listIdentifiers();
+	natcasesort($tz_list);
+
+	static $replace = ['/' => ' / ', '_' => ' '];
+
+	foreach ($tz_list as $tz) {
+		$tz_continent = strtok($tz, '/');
+
+		if (!isset($continent) || $tz_continent !== $continent) {
+			if (isset($continent)) {
+				$out .= '</optgroup>';
+			}
+
+			$continent = $tz_continent;
+			$out .= sprintf('<optgroup label="%s">', $continent);
+		}
+
+		$out .= sprintf('<option value="%s"%s>%s</option>',
+			htmlspecialchars($tz),
+			$tz === $selected ? ' selected="selected"' : '',
+			htmlspecialchars(strtr($tz, $replace))
+		);
+	}
+
+	$out .= '</optgroup></select>';
+
+	return $out;
+}
+
+function timezone_check($tz) {
+	return in_array($tz, \DateTimeZone::listIdentifiers(), true);
+}
+
+$_tz_cache = [];
+
+function timezone_get_offset($tz_name) {
+	if (isset($_tz_cache[$tz_name])) {
+		return $_tz_cache[$tz_name];
+	}
+
+	try {
+		$tz = new \DateTimeZone($tz_name);
+		$date = new \DateTime('now', $tz);
+		$offset = $date->getOffset();
+	}
+	catch (\Exception $e) {
+		$offset = -1;
+	}
+
+	$_tz_cache[$tz_name] = $offset;
+	return $offset;
 }

--- a/include/functions.php
+++ b/include/functions.php
@@ -305,6 +305,9 @@ function set_default_user()
 	$pun_user['disp_topics'] = $pun_config['o_disp_topics_default'];
 	$pun_user['disp_posts'] = $pun_config['o_disp_posts_default'];
 	$pun_user['timezone'] = $pun_config['o_default_timezone'];
+	// MODIF RL Bohwaz amélioration des Timezone.
+	// Suppression dst
+	// FIN MODIF Bohwaz
 	$pun_user['language'] = $pun_config['o_default_lang'];
 	$pun_user['style'] = $pun_config['o_default_style'];
 	$pun_user['is_guest'] = true;
@@ -988,7 +991,9 @@ function format_time($timestamp, $date_only = false, $date_format = null, $time_
 	if (is_null($user))
 		$user = $pun_user;
 
+	// MODIF RL Bohwaz amélioration des Timezone.
 	$diff = timezone_get_offset($user['timezone']);
+	// FIN MODIF Bohwaz
 	$timestamp += $diff;
 	$now = time();
 
@@ -2244,7 +2249,7 @@ function dump()
 	exit;
 }
 
-
+// MODIF RL Bohwaz amélioration des Timezone.
 function html_timezone_select($name, $selected = null) {
 	$out = sprintf('<select name="%s">', $name);
 
@@ -2300,3 +2305,4 @@ function timezone_get_offset($tz_name) {
 	$_tz_cache[$tz_name] = $offset;
 	return $offset;
 }
+// FIN MODIF Bohwaz

--- a/install.php
+++ b/install.php
@@ -1424,11 +1424,13 @@ else
 				'allow_null'	=> false,
 				'default'		=> '1'
 			),
+			// MODIF RL Bohwaz amélioration des Timezone.
 			'timezone'			=> array(
 				'datatype'		=> 'VARCHAR(255)',
 				'allow_null'	=> false,
 				'default'		=> '\''.$db->escape('Europe/Paris').'\'',
 			),
+			// FIN MODIF Bohwaz
 			'time_format'		=> array(
 				'datatype'		=> 'TINYINT(1)',
 				'allow_null'	=> false,
@@ -1542,7 +1544,9 @@ else
 		'o_parser_revision'			=> FORUM_PARSER_REVISION,
 		'o_board_title'				=> $title,
 		'o_board_desc'				=> $description,
+		// MODIF RL Bohwaz amélioration des Timezone.
 		'o_default_timezone'		=> 'Europe/Paris',
+		// FIN MODIF Bohwaz
 		'o_time_format'				=> 'H:i:s',
 		'o_date_format'				=> 'Y-m-d',
 		'o_timeout_visit'			=> 1800,
@@ -1598,6 +1602,9 @@ else
 		'o_rules_message'			=> $lang_install['Rules'],
 		'o_maintenance'				=> 0,
 		'o_maintenance_message'		=> $lang_install['Maintenance message'],
+		// MODIF RL Bohwaz amélioration des Timezone.
+		// suppression dst
+		// FIN MODIF Bohwaz
 		'o_feed_type'				=> 2,
 		'o_feed_ttl'				=> 0,
 		'p_message_bbcode'			=> 1,

--- a/install.php
+++ b/install.php
@@ -1425,14 +1425,9 @@ else
 				'default'		=> '1'
 			),
 			'timezone'			=> array(
-				'datatype'		=> 'FLOAT',
+				'datatype'		=> 'VARCHAR(255)',
 				'allow_null'	=> false,
-				'default'		=> '0'
-			),
-			'dst'				=> array(
-				'datatype'		=> 'TINYINT(1)',
-				'allow_null'	=> false,
-				'default'		=> '0'
+				'default'		=> '\''.$db->escape('Europe/Paris').'\'',
 			),
 			'time_format'		=> array(
 				'datatype'		=> 'TINYINT(1)',
@@ -1547,7 +1542,7 @@ else
 		'o_parser_revision'			=> FORUM_PARSER_REVISION,
 		'o_board_title'				=> $title,
 		'o_board_desc'				=> $description,
-		'o_default_timezone'		=> 0,
+		'o_default_timezone'		=> 'Europe/Paris',
 		'o_time_format'				=> 'H:i:s',
 		'o_date_format'				=> 'Y-m-d',
 		'o_timeout_visit'			=> 1800,
@@ -1603,7 +1598,6 @@ else
 		'o_rules_message'			=> $lang_install['Rules'],
 		'o_maintenance'				=> 0,
 		'o_maintenance_message'		=> $lang_install['Maintenance message'],
-		'o_default_dst'				=> 0,
 		'o_feed_type'				=> 2,
 		'o_feed_ttl'				=> 0,
 		'p_message_bbcode'			=> 1,

--- a/profile.php
+++ b/profile.php
@@ -745,7 +745,9 @@ else if (isset($_POST['form_sent']))
 			$form = array(
 				'time_format'	=> intval($_POST['form']['time_format']),
 				'date_format'	=> intval($_POST['form']['date_format']),
+				// MODIF RL Bohwaz amélioration des Timezone.
 				'timezone' => trim($_POST['form']['timezone']),
+				// FIN MODIF Bohwaz
 			);
 
 			// Make sure we got a valid language string
@@ -1043,7 +1045,9 @@ else if (isset($_POST['form_sent']))
 flux_hook('profile_after_form_handling');
 
 
+// MODIF RL Bohwaz amélioration des Timezone.
 $result = $db->query('SELECT u.username, u.email, u.title, u.realname, u.url, u.jabber, u.icq, u.msn, u.aim, u.yahoo, u.location, u.signature, u.disp_topics, u.disp_posts, u.email_setting, u.notify_with_post, u.auto_notify, u.show_smilies, u.show_img, u.show_img_sig, u.show_avatars, u.show_sig, u.timezone, u.language, u.style, u.num_posts, u.last_post, u.registered, u.registration_ip, u.admin_note, u.date_format, u.time_format, u.last_visit, g.g_id, g.g_user_title, g.g_moderator FROM '.$db->prefix.'users AS u LEFT JOIN '.$db->prefix.'groups AS g ON g.g_id=u.group_id WHERE u.id='.$id) or error('Unable to fetch user info', __FILE__, __LINE__, $db->error());
+// FIN MODIF Bohwaz
 if (!$db->num_rows($result))
 	message($lang_common['Bad request'], false, '404 Not Found');
 
@@ -1336,7 +1340,9 @@ else
 							<label><?php echo $lang_prof_reg['Time zone']."\n" ?>
 							<br />
 
+							<?php // MODIF RL Bohwaz amélioration des Timezone. ?>
 							<?=html_timezone_select('form[timezone]', $user['timezone'])?>
+							<?php // FIN MODIF Bohwaz ?>
 
 							</label>
 							<label><?php echo $lang_prof_reg['Time format'] ?>

--- a/profile.php
+++ b/profile.php
@@ -743,10 +743,9 @@ else if (isset($_POST['form_sent']))
 		case 'essentials':
 		{
 			$form = array(
-				'timezone'		=> floatval($_POST['form']['timezone']),
-				'dst'			=> isset($_POST['form']['dst']) ? '1' : '0',
 				'time_format'	=> intval($_POST['form']['time_format']),
 				'date_format'	=> intval($_POST['form']['date_format']),
+				'timezone' => trim($_POST['form']['timezone']),
 			);
 
 			// Make sure we got a valid language string
@@ -1044,7 +1043,7 @@ else if (isset($_POST['form_sent']))
 flux_hook('profile_after_form_handling');
 
 
-$result = $db->query('SELECT u.username, u.email, u.title, u.realname, u.url, u.jabber, u.icq, u.msn, u.aim, u.yahoo, u.location, u.signature, u.disp_topics, u.disp_posts, u.email_setting, u.notify_with_post, u.auto_notify, u.show_smilies, u.show_img, u.show_img_sig, u.show_avatars, u.show_sig, u.timezone, u.dst, u.language, u.style, u.num_posts, u.last_post, u.registered, u.registration_ip, u.admin_note, u.date_format, u.time_format, u.last_visit, g.g_id, g.g_user_title, g.g_moderator FROM '.$db->prefix.'users AS u LEFT JOIN '.$db->prefix.'groups AS g ON g.g_id=u.group_id WHERE u.id='.$id) or error('Unable to fetch user info', __FILE__, __LINE__, $db->error());
+$result = $db->query('SELECT u.username, u.email, u.title, u.realname, u.url, u.jabber, u.icq, u.msn, u.aim, u.yahoo, u.location, u.signature, u.disp_topics, u.disp_posts, u.email_setting, u.notify_with_post, u.auto_notify, u.show_smilies, u.show_img, u.show_img_sig, u.show_avatars, u.show_sig, u.timezone, u.language, u.style, u.num_posts, u.last_post, u.registered, u.registration_ip, u.admin_note, u.date_format, u.time_format, u.last_visit, g.g_id, g.g_user_title, g.g_moderator FROM '.$db->prefix.'users AS u LEFT JOIN '.$db->prefix.'groups AS g ON g.g_id=u.group_id WHERE u.id='.$id) or error('Unable to fetch user info', __FILE__, __LINE__, $db->error());
 if (!$db->num_rows($result))
 	message($lang_common['Bad request'], false, '404 Not Found');
 
@@ -1335,52 +1334,11 @@ else
 						<div class="infldset">
 							<p><?php echo $lang_prof_reg['Time zone info'] ?></p>
 							<label><?php echo $lang_prof_reg['Time zone']."\n" ?>
-							<br /><select name="form[timezone]">
-								<option value="-12"<?php if ($user['timezone'] == -12) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-12:00'] ?></option>
-								<option value="-11"<?php if ($user['timezone'] == -11) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-11:00'] ?></option>
-								<option value="-10"<?php if ($user['timezone'] == -10) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-10:00'] ?></option>
-								<option value="-9.5"<?php if ($user['timezone'] == -9.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-09:30'] ?></option>
-								<option value="-9"<?php if ($user['timezone'] == -9) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-09:00'] ?></option>
-								<option value="-8.5"<?php if ($user['timezone'] == -8.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-08:30'] ?></option>
-								<option value="-8"<?php if ($user['timezone'] == -8) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-08:00'] ?></option>
-								<option value="-7"<?php if ($user['timezone'] == -7) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-07:00'] ?></option>
-								<option value="-6"<?php if ($user['timezone'] == -6) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-06:00'] ?></option>
-								<option value="-5"<?php if ($user['timezone'] == -5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-05:00'] ?></option>
-								<option value="-4"<?php if ($user['timezone'] == -4) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-04:00'] ?></option>
-								<option value="-3.5"<?php if ($user['timezone'] == -3.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-03:30'] ?></option>
-								<option value="-3"<?php if ($user['timezone'] == -3) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-03:00'] ?></option>
-								<option value="-2"<?php if ($user['timezone'] == -2) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-02:00'] ?></option>
-								<option value="-1"<?php if ($user['timezone'] == -1) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-01:00'] ?></option>
-								<option value="0"<?php if ($user['timezone'] == 0) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC'] ?></option>
-								<option value="1"<?php if ($user['timezone'] == 1) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+01:00'] ?></option>
-								<option value="2"<?php if ($user['timezone'] == 2) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+02:00'] ?></option>
-								<option value="3"<?php if ($user['timezone'] == 3) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+03:00'] ?></option>
-								<option value="3.5"<?php if ($user['timezone'] == 3.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+03:30'] ?></option>
-								<option value="4"<?php if ($user['timezone'] == 4) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+04:00'] ?></option>
-								<option value="4.5"<?php if ($user['timezone'] == 4.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+04:30'] ?></option>
-								<option value="5"<?php if ($user['timezone'] == 5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:00'] ?></option>
-								<option value="5.5"<?php if ($user['timezone'] == 5.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:30'] ?></option>
-								<option value="5.75"<?php if ($user['timezone'] == 5.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:45'] ?></option>
-								<option value="6"<?php if ($user['timezone'] == 6) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+06:00'] ?></option>
-								<option value="6.5"<?php if ($user['timezone'] == 6.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+06:30'] ?></option>
-								<option value="7"<?php if ($user['timezone'] == 7) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+07:00'] ?></option>
-								<option value="8"<?php if ($user['timezone'] == 8) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+08:00'] ?></option>
-								<option value="8.75"<?php if ($user['timezone'] == 8.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+08:45'] ?></option>
-								<option value="9"<?php if ($user['timezone'] == 9) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+09:00'] ?></option>
-								<option value="9.5"<?php if ($user['timezone'] == 9.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+09:30'] ?></option>
-								<option value="10"<?php if ($user['timezone'] == 10) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+10:00'] ?></option>
-								<option value="10.5"<?php if ($user['timezone'] == 10.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+10:30'] ?></option>
-								<option value="11"<?php if ($user['timezone'] == 11) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+11:00'] ?></option>
-								<option value="11.5"<?php if ($user['timezone'] == 11.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+11:30'] ?></option>
-								<option value="12"<?php if ($user['timezone'] == 12) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+12:00'] ?></option>
-								<option value="12.75"<?php if ($user['timezone'] == 12.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+12:45'] ?></option>
-								<option value="13"<?php if ($user['timezone'] == 13) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+13:00'] ?></option>
-								<option value="14"<?php if ($user['timezone'] == 14) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+14:00'] ?></option>
-							</select>
-							<br /></label>
-							<div class="rbox">
-								<label><input type="checkbox" name="form[dst]" value="1"<?php if ($user['dst'] == '1') echo ' checked="checked"' ?> /><?php echo $lang_prof_reg['DST'] ?><br /></label>
-							</div>
+							<br />
+
+							<?=html_timezone_select('form[timezone]', $user['timezone'])?>
+
+							</label>
 							<label><?php echo $lang_prof_reg['Time format'] ?>
 
 							<br /><select name="form[time_format]">

--- a/register.php
+++ b/register.php
@@ -151,11 +151,13 @@ if (isset($_POST['form_sent']))
 	else
 		$language = $pun_config['o_default_lang'];
 
+	// MODIF RL Bohwaz amélioration des Timezone.
 	$timezone = $_POST['timezone'];
 
 	if (!timezone_check($timezone)) {
 		$errors[] = 'Invalid timezone';
 	}
+	// FIN MODIF Bohwaz
 
 	$email_setting = intval($_POST['email_setting']);
 	if ($email_setting < 0 || $email_setting > 2)
@@ -173,7 +175,9 @@ if (isset($_POST['form_sent']))
 		$password_hash = pun_hash($password1);
 
 		// Add the user
+		// MODIF RL Bohwaz amélioration des Timezone.
 		$db->query('INSERT INTO '.$db->prefix.'users (username, group_id, password, email, email_setting, timezone, language, style, registered, registration_ip, last_visit) VALUES(\''.$db->escape($username).'\', '.$intial_group_id.', \''.$password_hash.'\', \''.$db->escape($email1).'\', '.$email_setting.', \''.$db->escape($timezone).'\' , \''.$db->escape($language).'\', \''.$pun_config['o_default_style'].'\', '.$now.', \''.$db->escape(get_remote_address()).'\', '.$now.')') or error('Unable to create user', __FILE__, __LINE__, $db->error());
+		// FIN MODIF Bohwaz
 		$new_uid = $db->insert_id();
 
 		if ($pun_config['o_regs_verify'] == '0')
@@ -287,6 +291,9 @@ define('PUN_ACTIVE_PAGE', 'register');
 require PUN_ROOT.'header.php';
 
 $timezone = isset($timezone) ? $timezone : $pun_config['o_default_timezone'];
+// MODIF RL Bohwaz amélioration des Timezone.
+// Suppression dst
+// FIN MODIF Bohwaz
 $email_setting = isset($email_setting) ? $email_setting : $pun_config['o_default_email_setting'];
 
 // If there are errors, we display them
@@ -365,7 +372,9 @@ if (!empty($errors))
 						<p><?php echo $lang_prof_reg['Time zone info'] ?></p>
 						<label><?php echo $lang_prof_reg['Time zone']."\n" ?>
 						<br />
+						<?php // MODIF RL Bohwaz amélioration des Timezone. ?>
 						<?=html_timezone_select('timezone', $timezone)?>
+						<?php // FIN MODIF Bohwaz ?>
 						</label>
 
 						<br />

--- a/register.php
+++ b/register.php
@@ -151,9 +151,11 @@ if (isset($_POST['form_sent']))
 	else
 		$language = $pun_config['o_default_lang'];
 
-	$timezone = round($_POST['timezone'], 1);
+	$timezone = $_POST['timezone'];
 
-	$dst = isset($_POST['dst']) ? '1' : '0';
+	if (!timezone_check($timezone)) {
+		$errors[] = 'Invalid timezone';
+	}
 
 	$email_setting = intval($_POST['email_setting']);
 	if ($email_setting < 0 || $email_setting > 2)
@@ -171,7 +173,7 @@ if (isset($_POST['form_sent']))
 		$password_hash = pun_hash($password1);
 
 		// Add the user
-		$db->query('INSERT INTO '.$db->prefix.'users (username, group_id, password, email, email_setting, timezone, dst, language, style, registered, registration_ip, last_visit) VALUES(\''.$db->escape($username).'\', '.$intial_group_id.', \''.$password_hash.'\', \''.$db->escape($email1).'\', '.$email_setting.', '.$timezone.' , '.$dst.', \''.$db->escape($language).'\', \''.$pun_config['o_default_style'].'\', '.$now.', \''.$db->escape(get_remote_address()).'\', '.$now.')') or error('Unable to create user', __FILE__, __LINE__, $db->error());
+		$db->query('INSERT INTO '.$db->prefix.'users (username, group_id, password, email, email_setting, timezone, language, style, registered, registration_ip, last_visit) VALUES(\''.$db->escape($username).'\', '.$intial_group_id.', \''.$password_hash.'\', \''.$db->escape($email1).'\', '.$email_setting.', '.$db->escape($timezone).' , \''.$db->escape($language).'\', \''.$pun_config['o_default_style'].'\', '.$now.', \''.$db->escape(get_remote_address()).'\', '.$now.')') or error('Unable to create user', __FILE__, __LINE__, $db->error());
 		$new_uid = $db->insert_id();
 
 		if ($pun_config['o_regs_verify'] == '0')
@@ -363,52 +365,12 @@ if (!empty($errors))
 					<div class="infldset">
 						<p><?php echo $lang_prof_reg['Time zone info'] ?></p>
 						<label><?php echo $lang_prof_reg['Time zone']."\n" ?>
-						<br /><select id="time_zone" name="timezone">
-							<option value="-12"<?php if ($timezone == -12) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-12:00'] ?></option>
-							<option value="-11"<?php if ($timezone == -11) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-11:00'] ?></option>
-							<option value="-10"<?php if ($timezone == -10) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-10:00'] ?></option>
-							<option value="-9.5"<?php if ($timezone == -9.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-09:30'] ?></option>
-							<option value="-9"<?php if ($timezone == -9) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-09:00'] ?></option>
-							<option value="-8.5"<?php if ($timezone == -8.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-08:30'] ?></option>
-							<option value="-8"<?php if ($timezone == -8) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-08:00'] ?></option>
-							<option value="-7"<?php if ($timezone == -7) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-07:00'] ?></option>
-							<option value="-6"<?php if ($timezone == -6) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-06:00'] ?></option>
-							<option value="-5"<?php if ($timezone == -5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-05:00'] ?></option>
-							<option value="-4"<?php if ($timezone == -4) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-04:00'] ?></option>
-							<option value="-3.5"<?php if ($timezone == -3.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-03:30'] ?></option>
-							<option value="-3"<?php if ($timezone == -3) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-03:00'] ?></option>
-							<option value="-2"<?php if ($timezone == -2) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-02:00'] ?></option>
-							<option value="-1"<?php if ($timezone == -1) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC-01:00'] ?></option>
-							<option value="0"<?php if ($timezone == 0) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC'] ?></option>
-							<option value="1"<?php if ($timezone == 1) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+01:00'] ?></option>
-							<option value="2"<?php if ($timezone == 2) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+02:00'] ?></option>
-							<option value="3"<?php if ($timezone == 3) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+03:00'] ?></option>
-							<option value="3.5"<?php if ($timezone == 3.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+03:30'] ?></option>
-							<option value="4"<?php if ($timezone == 4) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+04:00'] ?></option>
-							<option value="4.5"<?php if ($timezone == 4.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+04:30'] ?></option>
-							<option value="5"<?php if ($timezone == 5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:00'] ?></option>
-							<option value="5.5"<?php if ($timezone == 5.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:30'] ?></option>
-							<option value="5.75"<?php if ($timezone == 5.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+05:45'] ?></option>
-							<option value="6"<?php if ($timezone == 6) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+06:00'] ?></option>
-							<option value="6.5"<?php if ($timezone == 6.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+06:30'] ?></option>
-							<option value="7"<?php if ($timezone == 7) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+07:00'] ?></option>
-							<option value="8"<?php if ($timezone == 8) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+08:00'] ?></option>
-							<option value="8.75"<?php if ($timezone == 8.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+08:45'] ?></option>
-							<option value="9"<?php if ($timezone == 9) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+09:00'] ?></option>
-							<option value="9.5"<?php if ($timezone == 9.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+09:30'] ?></option>
-							<option value="10"<?php if ($timezone == 10) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+10:00'] ?></option>
-							<option value="10.5"<?php if ($timezone == 10.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+10:30'] ?></option>
-							<option value="11"<?php if ($timezone == 11) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+11:00'] ?></option>
-							<option value="11.5"<?php if ($timezone == 11.5) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+11:30'] ?></option>
-							<option value="12"<?php if ($timezone == 12) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+12:00'] ?></option>
-							<option value="12.75"<?php if ($timezone == 12.75) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+12:45'] ?></option>
-							<option value="13"<?php if ($timezone == 13) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+13:00'] ?></option>
-							<option value="14"<?php if ($timezone == 14) echo ' selected="selected"' ?>><?php echo $lang_prof_reg['UTC+14:00'] ?></option>
-						</select>
-						<br /></label>
-						<div class="rbox">
-							<label><input type="checkbox" name="dst" value="1"<?php if ($dst == '1') echo ' checked="checked"' ?> /><?php echo $lang_prof_reg['DST'] ?><br /></label>
-						</div>
+						<br />
+						<?=html_timezone_select('timezone', $timezone)?>
+						</label>
+
+						<br />
+
 <?php
 
 		$languages = forum_list_langs();

--- a/register.php
+++ b/register.php
@@ -173,7 +173,7 @@ if (isset($_POST['form_sent']))
 		$password_hash = pun_hash($password1);
 
 		// Add the user
-		$db->query('INSERT INTO '.$db->prefix.'users (username, group_id, password, email, email_setting, timezone, language, style, registered, registration_ip, last_visit) VALUES(\''.$db->escape($username).'\', '.$intial_group_id.', \''.$password_hash.'\', \''.$db->escape($email1).'\', '.$email_setting.', '.$db->escape($timezone).' , \''.$db->escape($language).'\', \''.$pun_config['o_default_style'].'\', '.$now.', \''.$db->escape(get_remote_address()).'\', '.$now.')') or error('Unable to create user', __FILE__, __LINE__, $db->error());
+		$db->query('INSERT INTO '.$db->prefix.'users (username, group_id, password, email, email_setting, timezone, language, style, registered, registration_ip, last_visit) VALUES(\''.$db->escape($username).'\', '.$intial_group_id.', \''.$password_hash.'\', \''.$db->escape($email1).'\', '.$email_setting.', \''.$db->escape($timezone).'\' , \''.$db->escape($language).'\', \''.$pun_config['o_default_style'].'\', '.$now.', \''.$db->escape(get_remote_address()).'\', '.$now.')') or error('Unable to create user', __FILE__, __LINE__, $db->error());
 		$new_uid = $db->insert_id();
 
 		if ($pun_config['o_regs_verify'] == '0')
@@ -287,7 +287,6 @@ define('PUN_ACTIVE_PAGE', 'register');
 require PUN_ROOT.'header.php';
 
 $timezone = isset($timezone) ? $timezone : $pun_config['o_default_timezone'];
-$dst = isset($dst) ? $dst : $pun_config['o_default_dst'];
 $email_setting = isset($email_setting) ? $email_setting : $pun_config['o_default_email_setting'];
 
 // If there are errors, we display them


### PR DESCRIPTION
Les fuseaux sont désormais indexés selon leur nom d'identifiant (exemple : Europe/Paris), en utilisant la gestion native de PHP, ce qui permet de gérer les subtilités locales et l'heure d'été automatiquement.

Normalement les anciens fuseaux donnés en décalage en heure (-3.5, +2, etc.) sont transformés automatiquement vers la timezone la plus courante correspondant à ce décalage.

Attention : je n'ai pas de BDD RL existante pour vérifier que la migration fonctionne bien, donc à tester avant de mettre en prod.